### PR TITLE
test workflows

### DIFF
--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/repositories/CustomerRepository.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/repositories/CustomerRepository.java
@@ -10,7 +10,7 @@ import coderuth.k23.skincare_booking.models.Customer;
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, String> {
     Optional<Customer> findByUsername(String username);
-    Optional<Customer> findByEmail(String email);
+//    Optional<Customer> findByEmail(String email);
 
     boolean existsByUsername(String username);
     boolean existsByEmail (String email);


### PR DESCRIPTION
**Tiêu đề:** Loại bỏ phương thức `findByEmail` khỏi CustomerRepository

**Mô tả ngắn:** Loại bỏ phương thức `findByEmail` khỏi `CustomerRepository` vì nó không còn cần thiết trong các use case hiện tại.

**Mô tả chi tiết:**

Pull request này loại bỏ phương thức `findByEmail` khỏi interface `CustomerRepository`. Phương thức này ban đầu được sử dụng để tìm kiếm khách hàng theo địa chỉ email, nhưng chức năng này hiện không còn được sử dụng trong ứng dụng. Việc loại bỏ phương thức này giúp đơn giản hóa repository và tránh nhầm lẫn về các phương thức truy vấn có sẵn. Không có tác động nào đến các chức năng hiện có, vì phương thức này không được sử dụng.
