### PR TITLE
#43 create delete for feedback

### DIFF
--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/res/FeedbackController.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/res/FeedbackController.java
@@ -46,4 +46,10 @@ public class FeedbackController {
         return ResponseEntity.ok(ApiResponse.success("Feedback updated successfully"));
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteFeedback(@PathVariable Long id, @Valid @RequestBody FeedbackRequest feedbackRequest) {
+        feedbackService.deleteFeedback(id, feedbackRequest);
+        return ResponseEntity.ok(ApiResponse.success("Feedback deleted successfully"));
+    }
+
 }

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/FeedbackService.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/FeedbackService.java
@@ -1,6 +1,7 @@
 package coderuth.k23.skincare_booking.services;
 
 import coderuth.k23.skincare_booking.dtos.request.FeedbackRequest;
+import coderuth.k23.skincare_booking.security.*;
 import coderuth.k23.skincare_booking.models.*;
 import coderuth.k23.skincare_booking.repositories.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,6 +74,27 @@ public class FeedbackService {
         // Lưu Feedback đã cập nhật
         feedBackRepository.save(feedback);
     }
+
+    // Delete Feedback
+    public void deleteFeedback(Long id, FeedbackRequest feedbackRequest) {
+        // Tìm Feedback theo id
+        Feedback feedback = feedBackRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Feedback not found with id: " + id));
+
+        // Tìm Customer dựa trên username và email
+        Customer customer = customerRepository.findByUsernameAndEmail(feedbackRequest.getUsername(), feedbackRequest.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("Customer not found"));
+
+        // Kiểm tra xem Feedback có thuộc về Customer này không
+        if (!feedback.getCustomer().getId().equals(customer.getId())) {
+            throw new IllegalArgumentException("You are not authorized to delete this feedback");
+        }
+
+        // Xóa Feedback
+        feedBackRepository.delete(feedback);
+    }
+
+
 
     // Chuyển đổi từ Feedback sang FeedbackDTO
     private FeedbackRequest convertToDTO(Feedback feedback) {


### PR DESCRIPTION
**Tiêu đề:** Thêm API Xóa Feedback và cập nhật API CRUD cho SpaService

**Mô tả ngắn:** Pull request này thêm API cho phép xóa feedback và cập nhật API CRUD cho SpaService.

**Mô tả chi tiết:**

Pull request này bao gồm các thay đổi sau:

*   **Thêm API Xóa Feedback:**
    *   Thêm phương thức `deleteFeedback` vào `FeedbackController` để xử lý yêu cầu xóa feedback.
    *   Thêm phương thức `deleteFeedback` vào `FeedbackService` để thực hiện logic xóa feedback.
    *   API này xác thực người dùng và đảm bảo chỉ người dùng sở hữu feedback mới có thể xóa nó.
*   **Cập nhật API CRUD cho SpaService:**
    *   Hoàn thiện API CRUD cho SpaService (tạo, đọc, cập nhật, xóa).
    *   Tạo các DTO tương ứng (SpaServiceRequestDTO, SpaServiceResponseDTO).
    *   Tạo Repository và Service cho SpaService.
    *   *Lưu ý:* Controller cho SpaService đã bị xoá trong pull request này. Cần xem xét cách tích hợp chức năng này vào controller khác hoặc khôi phục controller này trong tương lai nếu cần thiết.

Các thay đổi này giúp cải thiện khả năng quản lý feedback và dịch vụ spa trong ứng dụng.
