### PR TITLE
#45 Fix Bug Register/Login Manager Authentication

### DIFF
--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/authentications/AuthsController.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/authentications/AuthsController.java
@@ -22,12 +22,10 @@ public class AuthsController {
     @Autowired
     private AuthService authService;
 
-
-
     @PostMapping("/manager/login")
     public ResponseEntity<ApiResponse<UserInfoResponse>> authenticaAdmin(@Valid @RequestBody LoginRequest loginRequest, HttpServletResponse response) {
-        UserInfoResponse userInfo = authService.authenticateManager(loginRequest, response);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("Admin authentication successful", userInfo));
+        UserInfoResponse userInfo = authService.authenticateUser(loginRequest, response);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("Authentication successful", userInfo));
     }
 
     @PostMapping("/login")
@@ -45,7 +43,7 @@ public class AuthsController {
     @PostMapping("/manager/register")
     public ResponseEntity<ApiResponse<Void>> registerAdmin(@Valid @RequestBody RegisterRequest registerRequest) {
         authService.registerManager(registerRequest);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created("Admin registered successfully"));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created("Registered successfully"));
     }
 
     @PostMapping("/refresh")

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/models/Manager.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/models/Manager.java
@@ -18,6 +18,16 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class Manager extends User {
 
+    @Builder.Default
+    private String userType = "MANAGER";
+
+    protected void onCreate() {
+        super.onCreate();
+        if (getRole() == null) {
+            setRole(Role.ROLE_MANAGER);
+        }
+    }
+
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     @OneToMany(mappedBy = "manager")

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/AuthService.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/AuthService.java
@@ -32,6 +32,9 @@ public class AuthService {
     private CustomerRepository customerRepository;
 
     @Autowired
+    private ManagerRepository managerRepository;
+
+    @Autowired
     private PasswordEncoder passwordEncoder;
 
     @Autowired
@@ -39,7 +42,7 @@ public class AuthService {
 
     @Autowired
     private RefreshTokenService refreshTokenService;
-  
+
     public UserInfoResponse authenticateUser(LoginRequest loginRequest, HttpServletResponse response) {
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
@@ -61,38 +64,6 @@ public class AuthService {
                 userDetails.getUsername(),
                 userDetails.getEmail(),
                 userDetails.getUserType(),
-                userDetails.getAuthorities().stream().findFirst().get().getAuthority());
-    }
-
-    public UserInfoResponse authenticateManager(LoginRequest loginRequest, HttpServletResponse response) {
-        // Xác thực thông tin đăng nhập
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(
-                        loginRequest.getUsername(),
-                        loginRequest.getPassword()));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
-
-        // Kiểm tra vai trò của người dùng
-//        if (!userDetails.getAuthorities().stream()
-//                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN"))) {
-//            throw new IllegalArgumentException("User is not an admin");
-//        }
-
-        // Tạo access token và refresh token
-        String accessToken = jwtUtil.generateAccessToken(authentication);
-        RefreshToken refreshToken = refreshTokenService.createRefreshToken(String.valueOf(userDetails.getId()));
-
-        // Thêm token vào cookie
-        jwtUtil.addAccessTokenCookie(response, accessToken);
-        jwtUtil.addRefreshTokenCookie(response, refreshToken.getToken());
-
-        // Trả về thông tin người dùng
-        return new UserInfoResponse(
-                userDetails.getId(),
-                userDetails.getUsername(),
-                userDetails.getEmail(),
                 userDetails.getAuthorities().stream().findFirst().get().getAuthority());
     }
 
@@ -130,7 +101,7 @@ public class AuthService {
         manager.setUsername(registerRequest.getUsername());
         manager.setPhone(registerRequest.getPhone());
         manager.setPassword(passwordEncoder.encode(registerRequest.getPassword()));
-        manager.setRole(User.Role.ROLE_MANAGER); // Gán vai trò ADMIN
+        manager.setRole(Manager.Role.ROLE_MANAGER); // Gán vai trò ADMIN
 
         managerRepository.save(manager);
     }


### PR DESCRIPTION
**Tiêu đề:** Sửa lỗi xác thực Người Quản Lý và đăng ký/đăng nhập

**Mô tả ngắn:** Bản sửa lỗi này giải quyết các vấn đề trong quy trình xác thực và đăng ký cho Người Quản Lý.

**Mô tả chi tiết:**

Pull Request này tập trung vào việc sửa lỗi và cải thiện quy trình xác thực và đăng ký cho Người Quản Lý. Các thay đổi chính bao gồm:

*   **#45 Sửa lỗi Xác Thực/Đăng Ký Người Quản Lý:**
    *   Thống nhất logic xác thực người dùng (bao gồm cả quản lý) vào phương thức `authenticateUser` trong `AuthService`. Phương thức `authenticateManager` đã bị loại bỏ.
    *   Sửa đổi điểm cuối `/manager/login` trong `AuthsController` để sử dụng phương thức `authenticateUser`.
    *   Cập nhật thông báo thành công chung cho xác thực.
    *   Xóa tiền tố "Admin" khỏi thông báo đăng ký thành công.
    *   Thêm `userType` mặc định và logic khởi tạo vai trò cho `Manager` model.
    *   Sửa logic gán quyền quản trị viên trong quy trình đăng ký `registerManager`.

Những thay đổi này giúp đơn giản hóa quy trình xác thực, cải thiện tính nhất quán và giải quyết các lỗi liên quan đến vai trò người dùng.
