### PR TITLE
GetDetails Info Of Customer, Staff, SkinTherapist

### DIFF
--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/res/CustomerController.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/res/CustomerController.java
@@ -1,0 +1,27 @@
+package coderuth.k23.skincare_booking.controllers.res;
+
+import coderuth.k23.skincare_booking.dtos.response.ApiResponse;
+import coderuth.k23.skincare_booking.dtos.response.CustomerInfoResponse;
+import coderuth.k23.skincare_booking.services.CustomerService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/customers")
+public class CustomerController {
+
+    @Autowired
+    private CustomerService customerService;
+
+    // Endpoint để lấy thông tin cơ bản của tất cả khách hàng
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CustomerInfoResponse>>> getAllCustomers() {
+        List<CustomerInfoResponse> customers = customerService.getAllCustomers();
+        return ResponseEntity.ok(ApiResponse.success("Customers retrieved successfully", customers));
+    }
+}

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/res/SkinTherapistController.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/res/SkinTherapistController.java
@@ -1,0 +1,25 @@
+package coderuth.k23.skincare_booking.controllers.res;
+
+import coderuth.k23.skincare_booking.dtos.response.ApiResponse;
+import coderuth.k23.skincare_booking.dtos.response.SkinTherapistInfoResponse;
+import coderuth.k23.skincare_booking.services.SkinTherapistService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/skin-therapists")
+public class SkinTherapistController {
+
+    @Autowired
+    private SkinTherapistService skinTherapistService;
+
+    // Endpoint để lấy thông tin cơ bản của tất cả SkinTherapist
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<SkinTherapistInfoResponse>>> getAllSkinTherapists() {
+        List<SkinTherapistInfoResponse> therapists = skinTherapistService.getAllSkinTherapists();
+        return ResponseEntity.ok(ApiResponse.success("Skin therapists retrieved successfully", therapists));
+    }
+}

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/res/StaffController.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/res/StaffController.java
@@ -1,0 +1,29 @@
+package coderuth.k23.skincare_booking.controllers.res;
+
+import coderuth.k23.skincare_booking.dtos.response.ApiResponse;
+import coderuth.k23.skincare_booking.dtos.response.StaffInfoResponse;
+import coderuth.k23.skincare_booking.dtos.response.UserInfoResponse;
+import coderuth.k23.skincare_booking.services.StaffService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/staffs")
+public class StaffController {
+
+    @Autowired
+    private StaffService staffService;
+
+    // Endpoint để lấy thông tin cơ bản của tất cả nhân viên
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<StaffInfoResponse>>> getAllStaff() {
+        List<StaffInfoResponse> staff = staffService.getAllStaff();
+        return ResponseEntity.ok(ApiResponse.success("Staff retrieved successfully", staff));
+    }
+}
+

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/dtos/response/CustomerInfoResponse.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/dtos/response/CustomerInfoResponse.java
@@ -1,0 +1,15 @@
+package coderuth.k23.skincare_booking.dtos.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+public class CustomerInfoResponse {
+    private UUID id;
+    private String username;
+    private String email;
+    private String phone;
+}

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/dtos/response/SkinTherapistInfoResponse.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/dtos/response/SkinTherapistInfoResponse.java
@@ -1,0 +1,15 @@
+package coderuth.k23.skincare_booking.dtos.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+public class SkinTherapistInfoResponse {
+    private UUID id;
+    private String username;
+    private String email;
+    private String phone;
+}

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/dtos/response/StaffInfoResponse.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/dtos/response/StaffInfoResponse.java
@@ -1,0 +1,15 @@
+package coderuth.k23.skincare_booking.dtos.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+public class StaffInfoResponse {
+    private UUID id;
+    private String username;
+    private String email;
+    private String phone;
+}

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/repositories/CustomerRepository.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/repositories/CustomerRepository.java
@@ -1,9 +1,14 @@
 package coderuth.k23.skincare_booking.repositories;
 
 import coderuth.k23.skincare_booking.models.Customer;
+import coderuth.k23.skincare_booking.models.SpaService;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
 
 @Repository
 public interface CustomerRepository extends UserBaseRepository<Customer> {
+    Optional<Customer> findByUsername(String username);
     // Add specific customer methods if needed
 }

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/repositories/SkinTherapistRepository.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/repositories/SkinTherapistRepository.java
@@ -1,11 +1,15 @@
 package coderuth.k23.skincare_booking.repositories;
+import coderuth.k23.skincare_booking.models.Customer;
 import org.springframework.stereotype.Repository;
 
 import coderuth.k23.skincare_booking.models.SkinTherapist;
+
+import java.util.Optional;
 
 @Repository
 public interface SkinTherapistRepository extends UserBaseRepository<SkinTherapist> {
     // This class can be used to add manager-specific queries if needed in the future.
     // Currently, it inherits all methods from UserBaseRepository.
+    Optional<SkinTherapist> findByUsername(String username);
 
 }

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/repositories/StaffRepository.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/repositories/StaffRepository.java
@@ -4,9 +4,12 @@ import org.springframework.stereotype.Repository;
 
 import coderuth.k23.skincare_booking.models.Staff;
 
+import java.util.Optional;
+
 @Repository
 public interface StaffRepository extends UserBaseRepository<Staff> {
     // This class can be used to add manager-specific queries if needed in the future.
     // Currently, it inherits all methods from UserBaseRepository.
+    Optional<Staff> findByUsername(String username);
 
 }

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/CustomerService.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/CustomerService.java
@@ -1,0 +1,33 @@
+package coderuth.k23.skincare_booking.services;
+
+import coderuth.k23.skincare_booking.dtos.response.CustomerInfoResponse;
+import coderuth.k23.skincare_booking.models.Customer;
+import coderuth.k23.skincare_booking.repositories.CustomerRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CustomerService {
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    // Lấy thông tin cơ bản của tất cả khách hàng
+    public List<CustomerInfoResponse> getAllCustomers() {
+        List<Customer> customers = customerRepository.findAll();
+        if (customers.isEmpty()) {
+            return Collections.emptyList(); // Trả về danh sách rỗng nếu không có dữ liệu
+        }
+        return customers.stream()
+                .map(customer -> new CustomerInfoResponse(
+                        customer.getId(),
+                        customer.getUsername() != null ? customer.getUsername() : "",
+                        customer.getEmail() != null ? customer.getEmail() : "",
+                        customer.getPhone() != null ? customer.getPhone() : ""))
+                .collect(Collectors.toList());
+    }
+}

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/SkinTherapistService.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/SkinTherapistService.java
@@ -1,0 +1,34 @@
+package coderuth.k23.skincare_booking.services;
+
+import coderuth.k23.skincare_booking.dtos.response.SkinTherapistInfoResponse;
+import coderuth.k23.skincare_booking.models.SkinTherapist;
+import coderuth.k23.skincare_booking.repositories.SkinTherapistRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+public class SkinTherapistService {
+
+    @Autowired
+    private SkinTherapistRepository skinTherapistRepository;
+
+    // Lấy thông tin cơ bản của tất cả SkinTherapist
+    public List<SkinTherapistInfoResponse> getAllSkinTherapists() {
+        List<SkinTherapist> therapists = skinTherapistRepository.findAll();
+        if (therapists.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return therapists.stream()
+                .map(t -> new SkinTherapistInfoResponse(
+                        t.getId(),
+                        Objects.requireNonNullElse(t.getUsername(), ""),
+                        Objects.requireNonNullElse(t.getEmail(), ""),
+                        Objects.requireNonNullElse(t.getPhone(), "")))
+                .collect(Collectors.toList());
+    }
+}

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/StaffService.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/StaffService.java
@@ -1,0 +1,33 @@
+package coderuth.k23.skincare_booking.services;
+
+import coderuth.k23.skincare_booking.dtos.response.StaffInfoResponse;
+import coderuth.k23.skincare_booking.models.Staff;
+import coderuth.k23.skincare_booking.repositories.StaffRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class StaffService {
+
+    @Autowired
+    private StaffRepository staffRepository;
+
+    // Lấy thông tin cơ bản của tất cả nhân viên
+    public List<StaffInfoResponse> getAllStaff() {
+        List<Staff> staff = staffRepository.findAll();
+        if (staff.isEmpty()) {
+            return Collections.emptyList(); // Trả về danh sách rỗng nếu không có dữ liệu
+        }
+        return staff.stream()
+                .map(s -> new StaffInfoResponse(
+                        s.getId(),
+                        s.getUsername() != null ? s.getUsername() : "",
+                        s.getEmail() != null ? s.getEmail() : "",
+                        s.getPhone() != null ? s.getPhone() : ""))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
**Tiêu đề:** Thêm API Lấy Thông Tin Cơ Bản của Khách Hàng, Nhân Viên và Kỹ Thuật Viên

**Mô tả ngắn:**

Pull request này thêm các API để lấy thông tin cơ bản (id, username, email, phone) của khách hàng, nhân viên và kỹ thuật viên.

**Mô tả chi tiết:**

Pull request này giới thiệu các endpoint mới cho phép truy xuất thông tin cơ bản của các đối tượng sau:

*   **Khách hàng:** `/api/customers` - Trả về danh sách thông tin cơ bản của tất cả khách hàng.
*   **Nhân viên:** `/api/staffs` - Trả về danh sách thông tin cơ bản của tất cả nhân viên.
*   **Kỹ thuật viên:** `/api/skin-therapists` - Trả về danh sách thông tin cơ bản của tất cả kỹ thuật viên.

Các thay đổi bao gồm:

*   Tạo các controller tương ứng (CustomerController, StaffController, SkinTherapistController) để xử lý các request API.
*   Tạo các DTO (Data Transfer Objects) để định nghĩa cấu trúc dữ liệu trả về (CustomerInfoResponse, StaffInfoResponse, SkinTherapistInfoResponse).
*   Tạo các service (CustomerService, StaffService, SkinTherapistService) để xử lý logic nghiệp vụ và truy vấn dữ liệu từ repository.
*   Thêm phương thức `findByUsername` vào các repository để tìm kiếm theo username.
*   Xử lý trường hợp danh sách trả về rỗng.
*   Sử dụng `Objects.requireNonNullElse` để xử lý các giá trị null cho username, email và phone.

Mục đích của pull request này là cung cấp một cách thức đơn giản và hiệu quả để lấy thông tin cơ bản của các đối tượng này, phục vụ cho các mục đích hiển thị, báo cáo hoặc tích hợp với các hệ thống khác.
