### PR TITLE
ChangePassWord

### DIFF
--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/authentications/AuthsController.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/authentications/AuthsController.java
@@ -1,5 +1,6 @@
 package coderuth.k23.skincare_booking.controllers.authentications;
 
+import coderuth.k23.skincare_booking.dtos.request.ChangePasswordRequest;
 import coderuth.k23.skincare_booking.models.Customer;
 import coderuth.k23.skincare_booking.repositories.CustomerRepository;
 import jakarta.servlet.http.HttpServletResponse;
@@ -9,6 +10,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 
 import coderuth.k23.skincare_booking.services.AuthService;
@@ -28,6 +32,7 @@ public class AuthsController {
 
     @Autowired
     private CustomerRepository customerRepository;
+
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<UserInfoResponse>> authenticateUser(@Valid @RequestBody LoginRequest loginRequest, HttpServletResponse response) {
@@ -81,4 +86,24 @@ public class AuthsController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("You've been signed out!"));
     }
 
+    @PostMapping("/change-password")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody ChangePasswordRequest request) {
+        try {
+            authService.changePassword(userDetails.getUsername(), request);
+            return ResponseEntity.ok(ApiResponse.success("Password changed successfully"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ApiResponse.error(e.getMessage()));
+        } catch (UsernameNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.error("An error occurred while changing the password"));
+        }
+    }
 }
+
+

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/dtos/request/ChangePasswordRequest.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/dtos/request/ChangePasswordRequest.java
@@ -1,0 +1,14 @@
+package coderuth.k23.skincare_booking.dtos.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ChangePasswordRequest {
+
+    @NotBlank
+    private String oldPassword;
+
+    @NotBlank
+    private String newPassword;
+}

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/mailing/AbstractEmailContext.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/mailing/AbstractEmailContext.java
@@ -26,4 +26,6 @@ public abstract class AbstractEmailContext {
     public Object put(String key, Object value) {
         return key == null ? null : this.context.put(key.intern(), value);
     }
+
+    public abstract String getBody();
 }

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/mailing/AccountVerificationEmailContext.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/mailing/AccountVerificationEmailContext.java
@@ -19,6 +19,11 @@ public class AccountVerificationEmailContext extends AbstractEmailContext {
         setTo(customer.getEmail());
     }
 
+    @Override
+    public String getBody() {
+        return "";
+    }
+
     public void setToken(String token) {
         this.token = token;
         put("token", token);

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/repositories/UserBaseRepository.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/repositories/UserBaseRepository.java
@@ -16,4 +16,5 @@ public interface UserBaseRepository<T extends User> extends JpaRepository<T, UUI
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
     boolean existsByPhone(String phone);
+
 }

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/SecureTokenService.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/SecureTokenService.java
@@ -47,4 +47,6 @@ public class SecureTokenService {
     public void removeToken(SecureToken token) {
         secureTokenRepository.delete(token);
     }
+
+
 }


### PR DESCRIPTION
**Tiêu đề:** Tính năng Thay đổi Mật khẩu

**Mô tả ngắn:** Thêm API để người dùng thay đổi mật khẩu của họ.

**Mô tả chi tiết:**

Pull request này thêm chức năng thay đổi mật khẩu cho người dùng. Các thay đổi chính bao gồm:

*   **Thêm API `/change-password`:** Endpoint này cho phép người dùng đã xác thực thay đổi mật khẩu của họ.
*   **DTO `ChangePasswordRequest`:** Định nghĩa cấu trúc dữ liệu cho yêu cầu thay đổi mật khẩu, bao gồm mật khẩu cũ và mật khẩu mới.
*   **Cập nhật `AuthService`:** Thêm logic để xác thực mật khẩu cũ, mã hóa mật khẩu mới và lưu vào cơ sở dữ liệu.
*   **Kiểm tra tính hợp lệ của mật khẩu:** Thêm các quy tắc xác thực cho mật khẩu mới (ví dụ: độ dài tối thiểu, ký tự đặc biệt).
*   **Sửa đổi luồng tìm kiếm User:** Sửa đổi lại cách tìm user để có thể lấy user từ các repo Customer, Manager, Staff, SkinTherapist

Những thay đổi này cho phép người dùng kiểm soát tốt hơn tính bảo mật của tài khoản của họ.
