### PR TITLE
#128 Add Center Schedule functionality for Manager, Staff, and Therap…

### DIFF
--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/pages/ManagerPageController.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/pages/ManagerPageController.java
@@ -44,6 +44,7 @@ public class ManagerPageController {
 
     @Autowired
     private FeedbackService feedbackService;
+
     @Autowired
     private CenterScheduleService centerScheduleService;
 
@@ -325,7 +326,7 @@ public class ManagerPageController {
         }
         return "redirect:/protected/manager/center-schedule";
     }
-    
+
     @GetMapping("/delete-service/{id}")
     public String deleteService(@PathVariable Long id, RedirectAttributes redirectAttributes) {
         try {

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/pages/SkinTherapistPageController.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/pages/SkinTherapistPageController.java
@@ -4,6 +4,7 @@ import coderuth.k23.skincare_booking.dtos.request.EditProfileRequest;
 import coderuth.k23.skincare_booking.models.SkinTherapist;
 import coderuth.k23.skincare_booking.models.Staff;
 import coderuth.k23.skincare_booking.repositories.SkinTherapistRepository;
+import coderuth.k23.skincare_booking.services.CenterScheduleService;
 import coderuth.k23.skincare_booking.services.SpaServiceService;
 import coderuth.k23.skincare_booking.services.TherapistService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,6 +30,9 @@ public class SkinTherapistPageController {
 
     @Autowired
     SpaServiceService spaServiceService;
+
+    @Autowired
+    private CenterScheduleService centerScheduleService;
 
     @ModelAttribute("currentURI")
     public String currentURI(HttpServletRequest request) {
@@ -92,27 +96,27 @@ public class SkinTherapistPageController {
         return "admin/Security/security";
     }
 
-//    @PostMapping("/change-password")
-//    public String changePassword(
-//            @RequestParam("currentPassword") String currentPassword,
-//            @RequestParam("newPassword") String newPassword,
-//            @RequestParam("confirmPassword") String confirmPassword,
-//            Principal principal,
-//            RedirectAttributes redirectAttributes) {
-//        String username = principal.getName();
-//        try {
-//            // Kiểm tra và thay đổi mật khẩu
-//            therapistService.changePassword(username, currentPassword, newPassword, confirmPassword);
-//
-//            // Thông báo thành công
-//            redirectAttributes.addFlashAttribute("successMessage", "Password changed successfully!");
-//        } catch (Exception e) {
-//            // Thông báo lỗi
-//            redirectAttributes.addFlashAttribute("errorMessage", "Failed to change password: " + e.getMessage());
-//        }
-//
-//        return "redirect:/protected/therapist/security";
-//    }
+    @PostMapping("/change-password")
+    public String changePassword(
+            @RequestParam("currentPassword") String currentPassword,
+            @RequestParam("newPassword") String newPassword,
+            @RequestParam("confirmPassword") String confirmPassword,
+            Principal principal,
+            RedirectAttributes redirectAttributes) {
+        String username = principal.getName();
+        try {
+            // Kiểm tra và thay đổi mật khẩu
+            therapistService.changePassword(username, currentPassword, newPassword, confirmPassword);
+
+            // Thông báo thành công
+            redirectAttributes.addFlashAttribute("successMessage", "Password changed successfully!");
+        } catch (Exception e) {
+            // Thông báo lỗi
+            redirectAttributes.addFlashAttribute("errorMessage", "Failed to change password: " + e.getMessage());
+        }
+
+        return "redirect:/protected/therapist/security";
+    }
 
     @GetMapping("/spa-services")
     public String spaServicesPage(Model model, Principal principal) {
@@ -123,5 +127,16 @@ public class SkinTherapistPageController {
         model.addAttribute("therapist", therapist);
         model.addAttribute("spaServicesList", spaServiceService.getAllServices());
         return "/admin/SpaServices/ListSpaServices/listSpaServices";
+    }
+
+    @GetMapping("/center-schedule")
+    public String getCenterSchedule(Model model, Principal principal) {
+        String username = principal.getName();
+        SkinTherapist therapist = skinTherapistRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("Therapist not found"));
+
+        model.addAttribute("therapist", therapist);
+        model.addAttribute("scheduleList", centerScheduleService.getAllSchedules());
+        return "admin/Schedules/centerSchedule";
     }
 }

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/pages/StaffPageController.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/pages/StaffPageController.java
@@ -4,10 +4,7 @@ import coderuth.k23.skincare_booking.dtos.request.EditProfileRequest;
 import coderuth.k23.skincare_booking.models.Manager;
 import coderuth.k23.skincare_booking.models.Staff;
 import coderuth.k23.skincare_booking.repositories.StaffRepository;
-import coderuth.k23.skincare_booking.services.CustomerService;
-import coderuth.k23.skincare_booking.services.SpaServiceService;
-import coderuth.k23.skincare_booking.services.StaffService;
-import coderuth.k23.skincare_booking.services.TherapistService;
+import coderuth.k23.skincare_booking.services.*;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -37,6 +34,9 @@ public class StaffPageController {
 
     @Autowired
     SpaServiceService spaServiceService;
+
+    @Autowired
+    private CenterScheduleService centerScheduleService;
 
     @ModelAttribute("currentURI")
     public String currentURI(HttpServletRequest request) {
@@ -147,5 +147,16 @@ public class StaffPageController {
         model.addAttribute("staff", staff);
         model.addAttribute("spaServicesList", spaServiceService.getAllServices());
         return "/admin/SpaServices/ListSpaServices/listSpaServices";
+    }
+
+    @GetMapping("/center-schedule")
+    public String getCenterSchedule(Model model, Principal principal) {
+        String username = principal.getName();
+        Staff staff = staffRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("Staff not found"));
+
+        model.addAttribute("staff", staff);
+        model.addAttribute("scheduleList", centerScheduleService.getAllSchedules());
+        return "admin/Schedules/centerSchedule";
     }
 }

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/TherapistService.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/TherapistService.java
@@ -1,6 +1,8 @@
 package coderuth.k23.skincare_booking.services;
 
+import coderuth.k23.skincare_booking.models.Manager;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import coderuth.k23.skincare_booking.models.SkinTherapist;
@@ -19,6 +21,9 @@ public class TherapistService {
 
     @Autowired
     private TherapistScheduleRepository therapistScheduleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     // Quản lý thông tin nhà trị liệu
     public List<SkinTherapist> getAllTherapists() {
@@ -66,5 +71,24 @@ public class TherapistService {
 
     public void deleteSchedule(UUID id) {
         therapistScheduleRepository.deleteById(id);
+    }
+
+    public void changePassword(String username, String currentPassword, String newPassword, String confirmPassword) {
+        SkinTherapist skinTherapist = skinTherapistRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("Skin Therapist not found"));
+
+        // Kiểm tra mật khẩu hiện tại
+        if (!passwordEncoder.matches(currentPassword, skinTherapist.getPassword())) {
+            throw new RuntimeException("Current password is incorrect");
+        }
+
+        // Kiểm tra mật khẩu mới và xác nhận mật khẩu
+        if (!newPassword.equals(confirmPassword)) {
+            throw new RuntimeException("New password and confirm password do not match");
+        }
+
+        // Cập nhật mật khẩu
+        skinTherapist.setPassword(passwordEncoder.encode(newPassword));
+        skinTherapistRepository.save(skinTherapist);
     }
 }

--- a/SkinCare_Booking/src/main/resources/templates/admin/Profile/profile.html
+++ b/SkinCare_Booking/src/main/resources/templates/admin/Profile/profile.html
@@ -51,10 +51,12 @@
                             <div class="nav-align-top">
                                 <ul class="nav nav-pills flex-column flex-md-row mb-6 gap-md-0 gap-2">
                                     <li class="nav-item">
-                                        <a class="nav-link active" th:href="${#strings.contains(currentURI, 'manager') ? '/protected/manager/profile' : '/protected/staff/profile'}"><i class="icon-base bx bx-user icon-sm me-1_5"></i> Account</a>
+                                        <a class="nav-link active" th:href="${#strings.contains(currentURI, 'manager') ? '/protected/manager/profile' :
+                                                                            (#strings.contains(currentURI, 'staff') ? '/protected/staff/profile' : '/protected/therapist/profile')}"><i class="icon-base bx bx-user icon-sm me-1_5"></i> Account</a>
                                     </li>
                                     <li class="nav-item">
-                                        <a class="nav-link" th:href="${#strings.contains(currentURI, 'manager') ? '/protected/manager/security' : '/protected/staff/security'}"><i class="icon-base bx bx-lock-alt icon-sm me-1_5"></i> Security</a>
+                                        <a class="nav-link" th:href="${#strings.contains(currentURI, 'manager') ? '/protected/manager/security' :
+                                                                        (#strings.contains(currentURI, 'staff') ? '/protected/staff/security' : '/protected/therapist/security')}"><i class="icon-base bx bx-lock-alt icon-sm me-1_5"></i> Security</a>
                                     </li>
                                 </ul>
                             </div>
@@ -80,19 +82,20 @@
                                     </div>
                                 </div>
                                 <div class="card-body pt-4">
-                                    <form th:action="${#strings.contains(currentURI, 'manager') ? '/protected/manager/edit-profile' : '/protected/staff/edit-profile'}" method="post">
+                                    <form th:action="${#strings.contains(currentURI, 'manager') ? '/protected/manager/edit-profile' :
+                                                       (#strings.contains(currentURI, 'staff') ? '/protected/staff/edit-profile' : '/protected/therapist/edit-profile')}" method="post">
                                         <div class="row g-6">
                                             <div class="col-md-6 form-control-validation">
                                                 <label for="username" class="form-label">User Name</label>
-                                                <input class="form-control" type="text" id="username" name="username" th:value="${#strings.contains(currentURI, 'manager') ? manager.username : staff.username}" readonly/>
+                                                <input class="form-control" type="text" id="username" name="username" th:value="${#strings.contains(currentURI, 'manager') ? manager.username : (#strings.contains(currentURI, 'staff') ? staff.username : therapist.username)}" readonly/>
                                             </div>
                                             <div class="col-md-6 form-control-validation">
                                                 <label for="fullName" class="form-label">Full Name</label>
-                                                <input class="form-control" type="text" name="fullName" id="fullName" th:value="${#strings.contains(currentURI, 'manager') ? manager.fullName : staff.fullName}" />
+                                                <input class="form-control" type="text" name="fullName" id="fullName" th:value="${#strings.contains(currentURI, 'manager') ? manager.fullName : (#strings.contains(currentURI, 'staff') ? staff.fullName : therapist.fullName)}" />
                                             </div>
                                             <div class="col-md-6">
                                                 <label for="email" class="form-label">E-mail</label>
-                                                <input class="form-control" type="text" id="email" name="email" th:value="${#strings.contains(currentURI, 'manager') ? manager.email : staff.email}" placeholder="user@example.com" readonly/>
+                                                <input class="form-control" type="text" id="email" name="email" th:value="${#strings.contains(currentURI, 'manager') ? manager.email : (#strings.contains(currentURI, 'staff') ? staff.email : therapist.email)}" placeholder="user@example.com" readonly/>
                                             </div>
                                             <div class="col-md-6">
                                                 <label class="form-label" for="phone">Phone Number</label>
@@ -103,16 +106,16 @@
                                                            class="form-control"
                                                            pattern="^(\\+84|0)[1-9][0-9]{8}$"
                                                            title="Invalid phone number format. Ex: 0987654321 or +84987654321"
-                                                           th:value="${#strings.contains(currentURI, 'manager') ? manager.phone : staff.phone}" placeholder="0853902934" />
+                                                           th:value="${#strings.contains(currentURI, 'manager') ? manager.phone : (#strings.contains(currentURI, 'staff') ? staff.phone : therapist.phone)}" placeholder="0853902934" />
                                                 </div>
                                             </div>
                                             <div class="col-md-6">
                                                 <label for="location" class="form-label">Address</label>
-                                                <input type="text" class="form-control" id="location" name="location" th:value="${#strings.contains(currentURI, 'manager') ? manager.location : staff.location}" placeholder="Address" />
+                                                <input type="text" class="form-control" id="location" name="location" th:value="${#strings.contains(currentURI, 'manager') ? manager.location : (#strings.contains(currentURI, 'staff') ? staff.location : therapist.location)}" placeholder="Address" />
                                             </div>
                                             <div class="col-md-6">
                                                 <label for="img" class="form-label">Img</label>
-                                                <input type="url" class="form-control" id="img" name="img" th:value="${#strings.contains(currentURI, 'manager') ? manager.img : staff.img}" placeholder="Address" />
+                                                <input type="url" class="form-control" id="img" name="img" th:value="${#strings.contains(currentURI, 'manager') ? manager.img : (#strings.contains(currentURI, 'staff') ? staff.img : therapist.img)}" placeholder="Address" />
                                             </div>
                                         </div>
                                         <div class="mt-6">

--- a/SkinCare_Booking/src/main/resources/templates/admin/Schedules/centerSchedule.html
+++ b/SkinCare_Booking/src/main/resources/templates/admin/Schedules/centerSchedule.html
@@ -37,7 +37,7 @@
                 <div class="container-xxl flex-grow-1 container-p-y">
                     <!-- Center Schedule List -->
                     <div class="card">
-                        <div class="row mx-3 my-0 justify-content-between">
+                        <div th:if="${#strings.contains(currentURI, 'manager')}" class="row mx-3 my-0 justify-content-between">
                             <div class="py-3 d-flex align-items-center justify-content-between flex-wrap gap-3">
                                 <h5 class="mb-0">Center Schedule List</h5>
                                 <button class="btn btn-primary" type="button" data-bs-toggle="modal" data-bs-target="#addScheduleModal">
@@ -46,7 +46,7 @@
                             </div>
                         </div>
                         <div class="table-responsive">
-                            <div class="container mt-3">
+                            <div th:if="${#strings.contains(currentURI, 'manager')}" class="container mt-3">
                                 <!-- Alert for Success -->
                                 <div th:if="${successMessage}" class="alert alert-success alert-dismissible fade show position-relative" role="alert">
                                     <span th:text="${successMessage}"></span>
@@ -76,8 +76,8 @@
                                         <span th:if="${schedule.isClosed}" class="badge bg-danger">Closed</span>
                                         <span th:unless="${schedule.isClosed}" class="badge bg-success">Open</span>
                                     </td>
-                                    <td>
-                                        <button class="btn btn-sm btn-warning edit-btn"
+                                    <td th:if="${#strings.contains(currentURI, 'manager')}">
+                                        <button class="btn btn-sm btn-warning edit-btn mb-1 mb-sm-1"
                                                 th:data-id="${schedule.id}"
                                                 th:data-day-of-week="${schedule.dayOfWeek}"
                                                 th:data-start-time="${schedule.startTime}"
@@ -87,7 +87,7 @@
                                                 data-bs-target="#editScheduleModal">
                                             <i class="bx bx-edit me-1"></i> Edit
                                         </button>
-                                        <button class="btn btn-sm btn-danger delete-btn"
+                                        <button class="btn btn-sm btn-danger delete-btn mb-1 mb-sm-1"
                                                 th:data-id="${schedule.id}"
                                                 data-bs-toggle="modal"
                                                 data-bs-target="#deleteConfirmModal">

--- a/SkinCare_Booking/src/main/resources/templates/admin/Security/security.html
+++ b/SkinCare_Booking/src/main/resources/templates/admin/Security/security.html
@@ -51,10 +51,10 @@
               <div class="nav-align-top">
                 <ul class="nav nav-pills flex-column flex-md-row mb-6 gap-md-0 gap-2">
                   <li class="nav-item">
-                    <a class="nav-link" th:href="${#strings.contains(currentURI, 'manager') ? '/protected/manager/profile' : '/protected/staff/profile'}"><i class="icon-base bx bx-user icon-sm me-1_5"></i> Account</a>
+                    <a class="nav-link" th:href="${#strings.contains(currentURI, 'manager') ? '/protected/manager/profile' : (#strings.contains(currentURI, 'staff') ? '/protected/staff/profile' : '/protected/therapist/profile')}"><i class="icon-base bx bx-user icon-sm me-1_5"></i> Account</a>
                   </li>
                   <li class="nav-item">
-                    <a class="nav-link active" th:href="${#strings.contains(currentURI, 'manager') ? '/protected/manager/security' : '/protected/staff/security'}"><i class="icon-base bx bx-lock-alt icon-sm me-1_5"></i> Security</a>
+                    <a class="nav-link active" th:href="${#strings.contains(currentURI, 'manager') ? '/protected/manager/security' : (#strings.contains(currentURI, 'staff') ? '/protected/staff/security' : '/protected/therapist/security')}"><i class="icon-base bx bx-lock-alt icon-sm me-1_5"></i> Security</a>
                   </li>
                 </ul>
               </div>
@@ -84,7 +84,7 @@
                   <h5 class="card-header">Change Password</h5>
                   <div class="card-body pt-1">
                     <form id="formAccountSettings"
-                          th:action="${#strings.contains(currentURI, 'manager') ? '/protected/manager/change-password' : '/protected/staff/change-password'}"
+                          th:action="${#strings.contains(currentURI, 'manager') ? '/protected/manager/change-password' : (#strings.contains(currentURI, 'staff') ? '/protected/staff/change-password' : '/protected/therapist/change-password')}"
                           method="post">
                       <div class="row">
                         <div class="mb-6 col-md-6 form-password-toggle form-control-validation">

--- a/SkinCare_Booking/src/main/resources/templates/admin/fragments/menu.html
+++ b/SkinCare_Booking/src/main/resources/templates/admin/fragments/menu.html
@@ -134,10 +134,13 @@
       </ul>
     </li>
     <!-- Center Schedule (Manager) -->
-    <li th:if="${#strings.contains(currentURI, 'manager')}"
+    <li
         class="menu-item"
-        th:classappend="${#strings.contains(currentURI, '/manager/center-schedule')} ? 'active' : ''">
-      <a th:href="@{/protected/manager/center-schedule}" class="menu-link">
+        th:classappend="${#strings.contains(currentURI, '/manager/center-schedule') or
+                          #strings.contains(currentURI, '/staff/center-schedule') or
+                          #strings.contains(currentURI, '/therapist/center-schedule')} ? 'active' : ''">
+      <a th:href="${#strings.contains(currentURI, 'manager') ? '/protected/manager/center-schedule' :
+                      (#strings.contains(currentURI, 'staff') ? '/protected/staff/center-schedule' : '/protected/therapist/center-schedule')}" class="menu-link">
         <i class="menu-icon tf-icons bx bx-calendar"></i>
         <div class="text-truncate" data-i18n="Dashboards">Center Schedule</div>
       </a>


### PR DESCRIPTION
**Tiêu đề:** Tính năng Lịch làm việc trung tâm cho Quản lý, Nhân viên và Kỹ thuật viên

**Mô tả ngắn:** Thêm chức năng quản lý lịch làm việc trung tâm cho các vai trò Quản lý, Nhân viên và Kỹ thuật viên; cập nhật các trang profile và bảo mật để điều hướng dựa trên vai trò.

**Mô tả chi tiết:**

Pull request này giới thiệu các thay đổi sau:

*   **Tính năng Lịch làm việc trung tâm:** Thêm chức năng hiển thị và quản lý lịch làm việc trung tâm cho vai trò Quản lý, Nhân viên và Kỹ thuật viên. Quản lý có thể tạo, chỉnh sửa và xóa lịch, trong khi Nhân viên và Kỹ thuật viên có thể xem lịch làm việc của trung tâm.
*   **Cập nhật trang Profile và Bảo mật:** Sửa đổi các trang profile và bảo mật để điều hướng dựa trên vai trò người dùng (Quản lý, Nhân viên, Kỹ thuật viên), đảm bảo mỗi người dùng chỉ thấy các tùy chọn phù hợp với vai trò của họ.
*   **Thay đổi Mật khẩu cho Therapist:** Thêm chức năng thay đổi mật khẩu cho Therapist.
    Các thay đổi này giúp tăng cường khả năng quản lý lịch làm việc và cải thiện trải nghiệm người dùng bằng cách cung cấp quyền truy cập phù hợp dựa trên vai trò.
