### PR TITLE
#129 Translate modal and toast messages to English; update service la…

### DIFF
--- a/SkinCare_Booking/src/main/resources/static/admin/assets/js/loadAppointment_form_modal.js
+++ b/SkinCare_Booking/src/main/resources/static/admin/assets/js/loadAppointment_form_modal.js
@@ -22,20 +22,20 @@ $(document).on("submit", "#appointmentForm", function(e) {
     dataType: "json", // Đảm bảo server trả về JSON
     success: function(resp) {
       if (resp.status === "success") {
-        showToast("Thành công", resp.message);
+        showToast("Success", resp.message);
       } else {
-        showToast("Lỗi", resp.message);
+        showToast("Error", resp.message);
       }
     },
     error: function(xhr) {
-      let errorMsg = "Có lỗi xảy ra!";
+      let errorMsg = "An error occurred!";
       try {
         let response = JSON.parse(xhr.responseText);
         errorMsg = response.message || errorMsg;
       } catch (e) {
         errorMsg = xhr.responseText || errorMsg;
       }
-      showToast("Lỗi", errorMsg);
+      showToast("Error", errorMsg);
     }
   });
 });

--- a/SkinCare_Booking/src/main/resources/templates/user/Modal/appointment_form_modal.html
+++ b/SkinCare_Booking/src/main/resources/templates/user/Modal/appointment_form_modal.html
@@ -4,8 +4,8 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="appointmentModalLabel">Đặt dịch vụ chăm sóc da</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          <h5 class="modal-title" id="appointmentModalLabel">Book a skin care service</h5>
+          <a th:href="@{/protected/customer/services}" class="btn btn-secondary">Close</a>
         </div>
         <!-- Phần này sẽ được nạp nội dung từ appointment_form -->
         <div class="modal-body" id="appointmentModalBody"></div>

--- a/SkinCare_Booking/src/main/resources/templates/user/customer/appointment_form.html
+++ b/SkinCare_Booking/src/main/resources/templates/user/customer/appointment_form.html
@@ -1,22 +1,20 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="">
 <head>
-    <title>Đặt dịch vụ chăm sóc da</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
     <div class="container">
-        <h1>Đặt dịch vụ chăm sóc da</h1> 
           <!-- Container Toast, ví dụ đặt ở góc phải trên của trang -->
         <div aria-live="polite" aria-atomic="true" class="position-fixed top-0 end-0 p-3" style="z-index: 1100;">
             <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
             <div class="toast-header">
-                <strong class="me-auto" id="toastTitle">Thông báo</strong>
-                <small class="text-muted">vừa xong</small>
+                <strong class="me-auto" id="toastTitle">Notification</strong>
+                <small class="text-muted">Now</small>
                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
             </div>
             <div class="toast-body" id="toastBody">
-                Nội dung thông báo...
+                Notification Content...
             </div>
             </div>
         </div>
@@ -36,25 +34,27 @@
 
         <form id="appointmentForm" th:object="${appointment}" method="post">
             <div class="mb-3">
-                <label>Dịch vụ:</label>
+                <label>Service:</label>
                 <select th:field="*{spaService.id}" class="form-control" required>
-                    <option value="">Chọn dịch vụ</option>
+                    <option value="">Chose Service</option>
                     <option th:each="service : ${services}" th:value="${service.id}" th:text="${service.name}"></option>
                 </select>
             </div>
             <div class="mb-3">
-                <label>Chuyên viên (không bắt buộc):</label>
+                <label>Skin Therapist (Optional):</label>
                 <select th:field="*{skinTherapist.id}" class="form-control">
-                    <option value="">Không chỉ định</option>
+                    <option value="">Not specified</option>
                     <option th:each="therapist : ${therapists}" th:value="${therapist.id}" th:text="${therapist.fullName}"></option>
                 </select>
             </div>
             <div class="mb-3">
-                <label>Thời gian:</label>
+                <label>Time:</label>
                 <input type="datetime-local" th:field="*{appointmentTime}" class="form-control" required/>
             </div>
-            <button type="submit" class="btn btn-primary">Đặt dịch vụ</button>
-            <a th:href="@{/protected/customer/appointments}" class="btn btn-secondary">Hủy</a>
+            <div class="d-flex gap-1 flex-row-reverse">
+                <button type="submit" class="btn btn-success btn-sm">Booking</button>
+                <a th:href="@{/protected/customer/services}" class="btn btn-secondary btn-sm">Cancel</a>
+            </div>
         </form>
     </div>
 </body>

--- a/SkinCare_Booking/src/main/resources/templates/user/services.html
+++ b/SkinCare_Booking/src/main/resources/templates/user/services.html
@@ -185,14 +185,12 @@
             </div>
 
             <!-- Kiểm tra nếu serviceList không null hoặc rỗng -->
-            <div class="row" th:if="${services != null}">
+            <div class="row">
                 <!-- Lặp và hiển thị mỗi service -->
                 <div class="col-12 col-md-6 col-lg-4"
                      th:each="service : ${services}"
                      th:with="
-                         bgimg=${(service != null and service.imageUrl != null and service.imageUrl != '') 
-                                     ? service.imageUrl 
-                                     : '/user/img/about-us-img/3.jpg'},
+                         bgimg=${service.imageUrl},
                          price=${service.price},
                          title=${service.name},
                          desc=${service.description},
@@ -219,36 +217,34 @@
                         </div>
                         <!-- Book Room -->
                         <!-- Thêm điều kiện để ẩn nút Book Now nếu giá <= 0 -->
-                        <a th:if="${service.price != null and service.price > 0}"
+                        <a class="book-room-btn btn palatin-btn" th:href="@{/login}">
+                            Book Now
+                        </a>
+                        <a th:if="${#strings.contains(currentURI, 'customer')}"
                            class="book-room-btn btn palatin-btn"
                            th:onclick="|loadAppointmentForm(${service.id})|"
                            href="javascript:void(0);">
                             Book Now
                         </a>
-                        <span th:unless="${service.price != null and service.price > 0}"
-                              class="text-danger">
-                            Dịch vụ không khả dụng
-                        </span>
                     </div>
                 </div>
                 <!-- Hiển thị thông báo nếu không có service -->
-                <!--<div th:if="${serviceList == null or #lists.isEmpty(serviceList)}">
-                    <p>Không có dịch vụ nào được hiển thị.</p>
-                </div> -->
+                <div th:if="${#lists.isEmpty(services)}">
+                    <p>No services are displayed.</p>
+                </div>
             </div>
             </div>
     </section>
         <!-- Appointment Form Modal -->
-    <div class="modal fade" id="appointmentModal" tabindex="-1" aria-labelledby="appointmentModalLabel" aria-hidden="true">
+    <div class="modal fade" data-bs-backdrop="static" data-bs-keyboard="false" id="appointmentModal" tabindex="-1" aria-labelledby="appointmentModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header">
-            <h5 class="modal-title" id="appointmentModalLabel">Đặt dịch vụ chăm sóc da</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="appointmentModalLabel">Book a skin care service</h5>
+                </div>
+                <!-- Phần này sẽ được nạp nội dung từ appointment_form -->
+                <div class="modal-body" id="appointmentModalBody"></div>
             </div>
-            <!-- Phần này sẽ được nạp nội dung từ appointment_form -->
-            <div class="modal-body" id="appointmentModalBody"></div>
-        </div>
         </div>
     </div>
     <!-- ##### Rooms Area End ##### -->


### PR DESCRIPTION
## Pull Request: [FEAT] Cập nhật giao diện và ngôn ngữ cho modal đặt lịch hẹn và thông báo

**Mô tả ngắn:**

Bản cập nhật này cải thiện giao diện người dùng và trải nghiệm người dùng bằng cách dịch các thông báo và cập nhật các nhãn dịch vụ và văn bản nút cho nhất quán.

**Mô tả chi tiết:**

PR này thực hiện các thay đổi sau:

*   **Dịch các thông báo (modal & toast) sang tiếng Anh:** Chuyển đổi các thông báo hiển thị trong modal đặt lịch hẹn và toast messages sang tiếng Anh, đảm bảo tính nhất quán và rõ ràng cho người dùng quốc tế.
*   **Cập nhật nhãn dịch vụ:** Điều chỉnh nhãn cho các dịch vụ khác nhau để đảm bảo chúng rõ ràng, dễ hiểu và nhất quán trên toàn bộ ứng dụng.
*   **Cập nhật văn bản nút:** Thay đổi văn bản trên các nút để phù hợp với luồng người dùng và cung cấp hướng dẫn rõ ràng hơn. Thay đổi này bao gồm nút "Đặt dịch vụ" thành "Booking" và bổ sung nút "Cancel" để người dùng có thể dễ dàng hủy thao tác.
*   **Điều chỉnh giao diện modal:** Cập nhật giao diện modal, thay đổi nút đóng từ một `button` tiêu chuẩn sang một thẻ `<a>` với chức năng điều hướng, cải thiện trải nghiệm người dùng bằng cách cho phép họ dễ dàng đóng modal và điều hướng trở lại trang dịch vụ.
*   **Ẩn nút "Book Now" nếu chưa đăng nhập.**
