### PR TITLE
#128 Add appointment statistics to ManagerPage: total appointments, c…

### DIFF
--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/pages/ManagerPageController.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/controllers/pages/ManagerPageController.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.stereotype.Repository;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -72,11 +71,20 @@ public class ManagerPageController {
         Manager manager = managerRepository.findByUsername(username)
                 .orElseThrow(() -> new RuntimeException("Manager not found"));
 
+        long totalAppointments = appointmentService.getTotalAppointments();
+        double cancellationRate = appointmentService.getCancellationRate();
+        double successRate = appointmentService.getSuccessRate();
+        SpaService mostBookedSpaService = appointmentService.getMostBookedSpaService();
+
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMMM", Locale.ENGLISH);
         String monthName = LocalDateTime.now().format(formatter);
 
         model.addAttribute("manager", manager);
         model.addAttribute("month", monthName);
+        model.addAttribute("totalAppointments", totalAppointments);
+        model.addAttribute("cancellationRate", String.format("%.2f", cancellationRate));
+        model.addAttribute("successRate", String.format("%.2f", successRate));
+        model.addAttribute("mostBookedSpaService", mostBookedSpaService != null ? mostBookedSpaService.getName() : "N/A");
         model.addAttribute("sales", appointmentService.calculateCurrentMonthRevenue());
         model.addAttribute("annualRevenue", appointmentService.calculateCurrentYearRevenue());
         return "admin/index"; // "user/index.html"

--- a/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/AppointmentService.java
+++ b/SkinCare_Booking/src/main/java/coderuth/k23/skincare_booking/services/AppointmentService.java
@@ -25,7 +25,9 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class AppointmentService {
@@ -414,5 +416,40 @@ public class AppointmentService {
 
         logger.info("Calculated current year revenue (only PAID payments): ${}", revenue);
         return revenue;
+    }
+
+    // Tổng số lịch hẹn
+    public long getTotalAppointments() {
+        return appointmentRepository.count();
+    }
+
+    // Tỉ lệ hủy lịch hẹn
+    public double getCancellationRate() {
+        long totalAppointments = getTotalAppointments();
+        long canceledAppointments = appointmentRepository.findByStatus(Appointment.AppointmentStatus.CANCELLED).size();
+        return totalAppointments > 0 ? (canceledAppointments * 100.0) / totalAppointments : 0.0;
+    }
+
+    // Tỉ lệ lịch hẹn thành công
+    public double getSuccessRate() {
+        long totalAppointments = getTotalAppointments();
+        long completedAppointments = appointmentRepository.findByStatus(Appointment.AppointmentStatus.COMPLETED).size();
+        return totalAppointments > 0 ? (completedAppointments * 100.0) / totalAppointments : 0.0;
+    }
+
+    // SpaService được đặt nhiều nhất
+    public SpaService getMostBookedSpaService() {
+        List<Appointment> allAppointments = appointmentRepository.findAll();
+        if (allAppointments.isEmpty()) {
+            return null;
+        }
+
+        Map<SpaService, Long> serviceCount = allAppointments.stream()
+                .collect(Collectors.groupingBy(Appointment::getSpaService, Collectors.counting()));
+
+        return serviceCount.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
     }
 }

--- a/SkinCare_Booking/src/main/resources/templates/admin/masterAdmin/masterAdminPage.html
+++ b/SkinCare_Booking/src/main/resources/templates/admin/masterAdmin/masterAdminPage.html
@@ -100,79 +100,63 @@
                 <div class="card-header d-flex justify-content-between">
                   <div class="card-title mb-0">
                     <h5 class="mb-1 me-2">Order Statistics</h5>
-                    <p class="card-subtitle">42.82k Total Sales</p>
+                    <p class="card-subtitle">Total Appointments: <span th:text="${totalAppointments}"></span></p>
                   </div>
                 </div>
                 <div class="card-body">
                   <div class="d-flex justify-content-between align-items-center mb-6">
                     <div class="d-flex flex-column align-items-center gap-1">
-                      <h3 class="mb-1">8,258</h3>
-                      <small>Total Orders</small>
+                      <h3 class="mb-1" th:text="${totalAppointments}"></h3>
+                      <small>Total Appointments</small>
                     </div>
                     <div id="orderStatisticsChart"></div>
                   </div>
                   <ul class="p-0 m-0">
                     <li class="d-flex align-items-center mb-5">
                       <div class="avatar flex-shrink-0 me-3">
-                            <span class="avatar-initial rounded bg-label-primary"
-                            ><i class="icon-base bx bx-mobile-alt"></i
-                            ></span>
+                        <span class="avatar-initial rounded bg-label-primary">
+                          <i class="icon-base bx bx-x-circle"></i>
+                        </span>
                       </div>
                       <div class="d-flex w-100 flex-wrap align-items-center justify-content-between gap-2">
                         <div class="me-2">
-                          <h6 class="mb-0">Electronic</h6>
-                          <small>Mobile, Earbuds, TV</small>
+                          <h6 class="mb-0">Cancellation Rate</h6>
+                          <small>Percentage of canceled appointments</small>
                         </div>
                         <div class="user-progress">
-                          <h6 class="mb-0">82.5k</h6>
+                          <h6 class="mb-0" th:text="${cancellationRate} + '%'"></h6>
                         </div>
                       </div>
                     </li>
                     <li class="d-flex align-items-center mb-5">
                       <div class="avatar flex-shrink-0 me-3">
-                            <span class="avatar-initial rounded bg-label-success"
-                            ><i class="icon-base bx bx-closet"></i
-                            ></span>
+                        <span class="avatar-initial rounded bg-label-success">
+                          <i class="icon-base bx bx-check-circle"></i>
+                        </span>
                       </div>
                       <div class="d-flex w-100 flex-wrap align-items-center justify-content-between gap-2">
                         <div class="me-2">
-                          <h6 class="mb-0">Fashion</h6>
-                          <small>T-shirt, Jeans, Shoes</small>
+                          <h6 class="mb-0">Success Rate</h6>
+                          <small>Percentage of completed appointments</small>
                         </div>
                         <div class="user-progress">
-                          <h6 class="mb-0">23.8k</h6>
-                        </div>
-                      </div>
-                    </li>
-                    <li class="d-flex align-items-center mb-5">
-                      <div class="avatar flex-shrink-0 me-3">
-                            <span class="avatar-initial rounded bg-label-info"
-                            ><i class="icon-base bx bx-home-alt"></i
-                            ></span>
-                      </div>
-                      <div class="d-flex w-100 flex-wrap align-items-center justify-content-between gap-2">
-                        <div class="me-2">
-                          <h6 class="mb-0">Decor</h6>
-                          <small>Fine Art, Dining</small>
-                        </div>
-                        <div class="user-progress">
-                          <h6 class="mb-0">849k</h6>
+                          <h6 class="mb-0" th:text="${successRate} + '%'"></h6>
                         </div>
                       </div>
                     </li>
                     <li class="d-flex align-items-center">
                       <div class="avatar flex-shrink-0 me-3">
-                            <span class="avatar-initial rounded bg-label-secondary"
-                            ><i class="icon-base bx bx-football"></i
-                            ></span>
+                        <span class="avatar-initial rounded bg-label-info">
+                          <i class="icon-base bx bx-star"></i>
+                        </span>
                       </div>
                       <div class="d-flex w-100 flex-wrap align-items-center justify-content-between gap-2">
                         <div class="me-2">
-                          <h6 class="mb-0">Sports</h6>
-                          <small>Football, Cricket Kit</small>
+                          <h6 class="mb-0">Most Booked Service</h6>
+                          <small>SpaService with the highest bookings</small>
                         </div>
                         <div class="user-progress">
-                          <h6 class="mb-0">10</h6>
+                          <h6 class="mb-0" th:text="${mostBookedSpaService}"></h6>
                         </div>
                       </div>
                     </li>


### PR DESCRIPTION
**Tiêu đề:** Thêm thống kê lịch hẹn vào trang quản lý

**Mô tả ngắn:**

Thêm các thống kê quan trọng về lịch hẹn vào trang quản lý (ManagerPage), bao gồm tổng số lịch hẹn, tỉ lệ hủy, tỉ lệ thành công và dịch vụ được đặt nhiều nhất.

**Mô tả chi tiết:**

Pull Request này bổ sung các thống kê sau vào trang quản lý (ManagerPage):

*   **Tổng số lịch hẹn:** Hiển thị tổng số lượng lịch hẹn đã được tạo.
*   **Tỉ lệ hủy lịch hẹn:** Tính toán và hiển thị tỉ lệ phần trăm các lịch hẹn bị hủy.
*   **Tỉ lệ lịch hẹn thành công:** Tính toán và hiển thị tỉ lệ phần trăm các lịch hẹn đã hoàn thành.
*   **Dịch vụ được đặt nhiều nhất:** Xác định và hiển thị dịch vụ spa được đặt nhiều nhất.

Các thay đổi này cung cấp cho người quản lý cái nhìn tổng quan về hiệu suất hoạt động, giúp họ đưa ra các quyết định sáng suốt hơn.

**Các thay đổi chính:**

*   `ManagerPageController.java`: Thêm các thuộc tính mới vào model để truyền dữ liệu thống kê đến view.
*   `AppointmentService.java`: Thêm các phương thức để tính toán các thống kê lịch hẹn: `getTotalAppointments()`, `getCancellationRate()`, `getSuccessRate()`, `getMostBookedSpaService()`.
*   `masterAdminPage.html`: Hiển thị các thống kê mới trong giao diện người dùng.
